### PR TITLE
Deployed to prod but fails as the bucket name (due to event fixing work) does not match the spec provided.

### DIFF
--- a/src/kixi/event_log_guardian/model.clj
+++ b/src/kixi/event_log_guardian/model.clj
@@ -5,7 +5,7 @@
 (s/def ::bucket-name
   (s/with-gen
     (s/and string?
-           #(re-matches #"(?:staging|prod)-witan-event-log" %))
+           #(re-matches #"^(?:staging|prod)-witan-event-log(?:-\d{8})?$" %))
     #(gen/elements ["staging-witan-event-log"
                     "prod-witan-event-log"])))
 (s/def ::key


### PR DESCRIPTION
What's more due to the bucket rename on fix-up activities the mesos guardian job will need redeploying to check the correct bucket.